### PR TITLE
Gradient support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ AccessModifierOffset: -4
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignOperands: false
-AlignTrailingComments: false
+AlignTrailingComments: true
 BreakBeforeBraces: Custom
 BreakConstructorInitializers: AfterColon
 BreakConstructorInitializersBeforeComma: false

--- a/examples/theme_customizing.cpp
+++ b/examples/theme_customizing.cpp
@@ -50,7 +50,7 @@ int main() {
         .layout_sections_per_page(2)
         // and paginate it
         .paginate_sections(true)
-        .theme_gradient_support(false)
+        .theme_gradient_support(true) // Enable gradient support
         /*
          *  Available presets
          *  GradientPreset::RAINBOW

--- a/examples/theme_customizing.cpp
+++ b/examples/theme_customizing.cpp
@@ -50,7 +50,8 @@ int main() {
         .layout_sections_per_page(2)
         // and paginate it
         .paginate_sections(true)
-        .theme_gradient_support(true) // Enable gradient support
+        .theme_gradient_support(true)    // Enable gradient support
+        .theme_gradient_randomize(false) // Randomize gradient
         /*
          *  Available presets
          *

--- a/examples/theme_customizing.cpp
+++ b/examples/theme_customizing.cpp
@@ -53,17 +53,24 @@ int main() {
         .theme_gradient_support(true) // Enable gradient support
         /*
          *  Available presets
+         *
+         *  NOTE: v_styles => std::vector<std::tuple<uint8_t, uint8_t, uint8_t>>
+         *
          *  GradientPreset::RAINBOW
          *  GradientPreset::BLUE_TO_PURPLE
          *  GradientPreset::RED_TO_GREEN
-         *  GradientPreset::FIRE            - Red to yellow
-         *  GradientPreset::FOREST          - Green to yellow-green
-         *  GradientPreset::OCEAN           - Blue to turquoise
-         *  GradientPreset::WARM_TO_COLD    - From orange to cyan
-         *  GradientPreset::SUNSET          - Red -> orange -> violet
-         *  GradientPreset::NONE            - None (by default)
+         *  GradientPreset::FIRE                        - Red to yellow
+         *  GradientPreset::FOREST                      - Green to yellow-green
+         *  GradientPreset::OCEAN                       - Blue to turquoise
+         *  GradientPreset::WARM_TO_COLD                - From orange to cyan
+         *  GradientPreset::SUNSET                      - Red -> orange -> violet
+         *  GradientPreset::CUSTOM(v_styles{r, g, b})   - custom colors (vector of rgb styles)
+         *  GradientPreset::NONE                        - None (by default)
          */
-        .theme_gradient_preset(GradientPreset::RAINBOW)
+        .theme_gradient_preset(GradientPreset::CUSTOM(v_styles{{255, 0, 0}, // red
+                                                               {0, 255, 0}, // green
+                                                               {0, 0, 255}} // blue
+                                                      ))
 
         // layout padding (you can enable if you want)
         // .layout_padding(3)

--- a/examples/theme_customizing.cpp
+++ b/examples/theme_customizing.cpp
@@ -30,7 +30,7 @@ int main() {
         // .theme_fancy()   // ✓  / ○
         // .theme_minimal() // * / nothing
         // .theme_modern()  // ● / "○
-        .theme_indicators('+', '-') // Custom indicators
+        .theme_indicators('+', '-')     // Custom indicators
         .theme_prefixes("[X] ", "[ ] ") // Custom prefixes
 
         // Set custom layout borders
@@ -50,6 +50,20 @@ int main() {
         .layout_sections_per_page(2)
         // and paginate it
         .paginate_sections(true)
+        .theme_gradient_support(false)
+        /*
+         *  Available presets
+         *  GradientPreset::RAINBOW
+         *  GradientPreset::BLUE_TO_PURPLE
+         *  GradientPreset::RED_TO_GREEN
+         *  GradientPreset::FIRE            - Red to yellow
+         *  GradientPreset::FOREST          - Green to yellow-green
+         *  GradientPreset::OCEAN           - Blue to turquoise
+         *  GradientPreset::WARM_TO_COLD    - From orange to cyan
+         *  GradientPreset::SUNSET          - Red -> orange -> violet
+         *  GradientPreset::NONE            - None (by default)
+         */
+        .theme_gradient_preset(GradientPreset::RAINBOW)
 
         // layout padding (you can enable if you want)
         // .layout_padding(3)

--- a/include/rebuildTUI/navigation_tui.hpp
+++ b/include/rebuildTUI/navigation_tui.hpp
@@ -16,7 +16,7 @@ namespace tui {
     class NavigationTUI {
     public:
         enum class NavigationState {
-            MAIN_MENU, ///< User is selecting a section (Main menu)
+            MAIN_MENU,     ///< User is selecting a section (Main menu)
             ITEM_SELECTION ///< User is selecting/managing items within a section
         };
 
@@ -24,15 +24,17 @@ namespace tui {
          * @brief Display theme configuration
          */
         struct Theme {
-            char selected_indicator = '*'; ///< Character for selected items
-            char unselected_indicator = ' '; ///< Character for unselected items
-            std::string selected_prefix = "✓ "; ///< Prefix for selected items
+            char selected_indicator = '*';        ///< Character for selected items
+            char unselected_indicator = ' ';      ///< Character for unselected items
+            std::string selected_prefix = "✓ ";   ///< Prefix for selected items
             std::string unselected_prefix = "  "; ///< Prefix for unselected items
-            bool use_unicode = true; ///< Whether to use Unicode characters
-            bool use_colors = true; ///< Whether to use ANSI colors
+            bool use_unicode = true;              ///< Whether to use Unicode characters
+            bool use_colors = true;               ///< Whether to use ANSI colors
+            bool gradient_enabled = false;        ///< Enable gradient support
             tui_extras::BorderStyle border_style =
                 tui_extras::BorderStyle::ROUNDED; ///< Border style: "rounded", "sharp", "double" and "ascii"
             tui_extras::AccentColor accent_color = tui_extras::AccentColor::CYAN; ///< Accent color for highlights
+            tui_extras::GradientPreset gradient_preset = tui_extras::GradientPreset::NONE; ///< Gradient preset
         };
 
         /**
@@ -40,15 +42,15 @@ namespace tui {
          */
         struct Layout {
             bool center_horizontally = true; ///< Center content horizontally on screen
-            bool center_vertically = true; ///< Center content vertically on screen
-            int max_content_width = 80; ///< Maximum width for content
-            int min_content_width = 40; ///< Minimum width for content
+            bool center_vertically = true;   ///< Center content vertically on screen
+            int max_content_width = 80;      ///< Maximum width for content
+            int min_content_width = 40;      ///< Minimum width for content
 
-            int vertical_padding = 2; ///< Padding from top/bottom when centering
+            int vertical_padding = 2;        ///< Padding from top/bottom when centering
             bool auto_resize_content = true; ///< Automatically resize content to fit terminal
 
             bool show_borders = true; ///< Whether to show borders around content
-            int items_per_page = 20; ///< Number of items to display per page
+            int items_per_page = 20;  ///< Number of items to display per page
 
             bool paginate_sections = true;
             int sections_per_page = 15; ///< Number of sections to display per page
@@ -65,9 +67,9 @@ namespace tui {
             std::string help_text_items =
                 "Space - toggle | Enter - select | b/Esc - back | "
                 "1-9 - page";
-            bool show_help_text = true; ///< Whether to show help text
+            bool show_help_text = true;    ///< Whether to show help text
             bool show_page_numbers = true; ///< Whether to show page navigation info
-            bool show_counters = true; ///< Whether to show selection counters
+            bool show_counters = true;     ///< Whether to show selection counters
         };
 
         /**
@@ -80,8 +82,8 @@ namespace tui {
 
             // Shortcuts
             std::map<char, std::string> custom_shortcuts; ///< Custom keyboard shortcuts
-            bool enable_quick_select = true; ///< Enable number keys for quick selection
-            bool enable_vim_keys = false; ///< Enable vim-style navigation (hjkl)
+            bool enable_quick_select = true;              ///< Enable number keys for quick selection
+            bool enable_vim_keys = false;                 ///< Enable vim-style navigation (hjkl)
         };
 
         /**
@@ -301,6 +303,7 @@ namespace tui {
         [[nodiscard]] std::string format_item_with_theme(const SelectableItem &item, bool is_selected) const;
         [[nodiscard]] std::string get_page_info_string() const;
         void apply_accent_color() const;
+        void apply_gradient_text(const std::string &text, int row, int col) const;
 
         /**
          * @brief Layout calculation

--- a/include/rebuildTUI/navigation_tui.hpp
+++ b/include/rebuildTUI/navigation_tui.hpp
@@ -303,7 +303,7 @@ namespace tui {
         // [[nodiscard]] std::vector<std::string> get_current_item_display_items() const;
         [[nodiscard]] std::string format_item_with_theme(const SelectableItem &item, bool is_selected) const;
         [[nodiscard]] std::string get_page_info_string() const;
-        void apply_accent_color() const;
+
         void apply_gradient_text(const std::string &text, int row, int col) const;
 
         /**

--- a/include/rebuildTUI/navigation_tui.hpp
+++ b/include/rebuildTUI/navigation_tui.hpp
@@ -366,6 +366,8 @@ namespace tui {
         NavigationBuilder &theme_prefixes(const std::string &selected, const std::string &unselected);
         NavigationBuilder &theme_unicode(bool enable);
         NavigationBuilder &theme_colors(bool enable);
+        NavigationBuilder &theme_gradient_support(bool enable);
+        NavigationBuilder &theme_gradient_preset(const tui_extras::GradientPreset &preset);
         NavigationBuilder &theme_border_style(const tui_extras::BorderStyle &style);
         NavigationBuilder &theme_accent_color(const tui_extras::AccentColor &color);
 

--- a/include/rebuildTUI/navigation_tui.hpp
+++ b/include/rebuildTUI/navigation_tui.hpp
@@ -31,6 +31,7 @@ namespace tui {
             bool use_unicode = true;              ///< Whether to use Unicode characters
             bool use_colors = true;               ///< Whether to use ANSI colors
             bool gradient_enabled = false;        ///< Enable gradient support
+            bool gradient_randomize = false;      ///< Randomize gradients
             tui_extras::BorderStyle border_style =
                 tui_extras::BorderStyle::ROUNDED; ///< Border style: "rounded", "sharp", "double" and "ascii"
             tui_extras::AccentColor accent_color = tui_extras::AccentColor::CYAN; ///< Accent color for highlights
@@ -368,6 +369,7 @@ namespace tui {
         NavigationBuilder &theme_colors(bool enable);
         NavigationBuilder &theme_gradient_support(bool enable);
         NavigationBuilder &theme_gradient_preset(const tui_extras::GradientPreset &preset);
+        NavigationBuilder &theme_gradient_randomize(bool enable);
         NavigationBuilder &theme_border_style(const tui_extras::BorderStyle &style);
         NavigationBuilder &theme_accent_color(const tui_extras::AccentColor &color);
 

--- a/include/rebuildTUI/navigation_tui.hpp
+++ b/include/rebuildTUI/navigation_tui.hpp
@@ -34,7 +34,7 @@ namespace tui {
             tui_extras::BorderStyle border_style =
                 tui_extras::BorderStyle::ROUNDED; ///< Border style: "rounded", "sharp", "double" and "ascii"
             tui_extras::AccentColor accent_color = tui_extras::AccentColor::CYAN; ///< Accent color for highlights
-            tui_extras::GradientPreset gradient_preset = tui_extras::GradientPreset::NONE; ///< Gradient preset
+            tui_extras::GradientPreset gradient_preset = tui_extras::GradientPreset::NONE(); ///< Gradient preset
         };
 
         /**

--- a/include/rebuildTUI/styles.hpp
+++ b/include/rebuildTUI/styles.hpp
@@ -2,7 +2,7 @@
 
 namespace tui_extras {
     enum class BorderStyle { ROUNDED, DOUBLE, SHARP, ASCII };
-  
+
     enum class AccentColor {
         CYAN,
         BLUE,
@@ -18,5 +18,17 @@ namespace tui_extras {
         BRIGHT_YELLOW,
         BRIGHT_MAGENTA,
         BRIGHT_WHITE
+    };
+
+    enum class GradientPreset {
+        NONE,
+        WARM_TO_COLD, // From orange to cyan
+        RED_TO_GREEN,
+        BLUE_TO_PURPLE,
+        SUNSET, // Red -> orange -> violet
+        OCEAN,  // Blue to turquoise
+        FOREST, // Green to yellow-green
+        FIRE,   // Red to yellow
+        RAINBOW // Rainbow
     };
 } // namespace tui_extras

--- a/include/rebuildTUI/styles.hpp
+++ b/include/rebuildTUI/styles.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cmath>
+#include <cstdint>
+#include <tuple>
+#include <vector>
+
 namespace tui_extras {
     enum class BorderStyle { ROUNDED, DOUBLE, SHARP, ASCII };
 
@@ -30,5 +35,107 @@ namespace tui_extras {
         FOREST, // Green to yellow-green
         FIRE,   // Red to yellow
         RAINBOW // Rainbow
+    };
+
+    class GradientColor {
+    public:
+        explicit GradientColor() : r_(0), g_(0), b_(0) {}
+        explicit GradientColor(const uint8_t r, const uint8_t g, const uint8_t b) : r_(r), g_(g), b_(b) {}
+
+        void set_rgb(const uint8_t r, const uint8_t g, const uint8_t b) {
+            this->r_ = r;
+            this->g_ = g;
+            this->b_ = b;
+        }
+
+        static std::vector<GradientColor> from_preset(const GradientPreset preset, const int steps) {
+            std::vector gradient(steps, GradientColor());
+            std::vector<GradientColor> color_points;
+
+            switch (preset) {
+            case GradientPreset::WARM_TO_COLD:
+                color_points = {GradientColor{255, 10, 0}, GradientColor{255, 255, 200}, GradientColor{100, 200, 255}};
+                break;
+            case GradientPreset::RED_TO_GREEN:
+                color_points = {GradientColor{255, 50, 50}, GradientColor{255, 255, 100}, GradientColor{50, 255, 50}};
+                break;
+            case GradientPreset::BLUE_TO_PURPLE:
+                color_points = {GradientColor{50, 100, 255}, GradientColor{150, 50, 255}, GradientColor{255, 50, 255}};
+                break;
+            case GradientPreset::SUNSET:
+                color_points = {GradientColor{255, 0, 100}, GradientColor{255, 100, 0}, GradientColor{150, 0, 255}};
+                break;
+            case GradientPreset::OCEAN:
+                color_points = {GradientColor{0, 50, 150}, GradientColor{0, 150, 255}, GradientColor{0, 255, 255}};
+                break;
+            case GradientPreset::FOREST:
+                color_points = {
+                    GradientColor{0, 100, 0},
+                    GradientColor{50, 200, 50},
+                    GradientColor{150, 255, 100},
+                };
+                break;
+            case GradientPreset::FIRE:
+                color_points = {
+                    GradientColor{255, 0, 0},
+                    GradientColor{255, 100, 0},
+                    GradientColor{255, 255, 0},
+                };
+                break;
+            case GradientPreset::RAINBOW:
+                for (auto i = 0; i < steps; i++) {
+                    const auto pos = static_cast<float>(i) / static_cast<float>(steps);
+                    const auto r = static_cast<uint8_t>(std::sin(0.3 * pos + 0) * 127 + 128);
+                    const auto g = static_cast<uint8_t>(std::sin(0.3 * pos + 2) * 127 + 128);
+                    const auto b = static_cast<uint8_t>(std::sin(0.3 * pos + 4) * 127 + 128);
+                    gradient.emplace_back(r, g, b);
+                    // gradient.emplace_back(static_cast<uint8_t>(r), static_cast<uint8_t>(g), static_cast<uint8_t>(b));
+                }
+                return gradient;
+            default:
+                return {GradientColor{255, 255, 255}};
+            }
+
+            const int segments = static_cast<int>(color_points.size()) - 1;
+            const auto segment_steps = static_cast<float>(steps) / static_cast<float>(segments);
+
+            for (auto seg = 0; seg < segments; seg++) {
+                const auto& start = color_points[seg];
+                const auto& end = color_points[seg + 1];
+
+                const auto seg_start = static_cast<int>(static_cast<float>(seg) * segment_steps);
+                const auto seg_end = static_cast<int>(static_cast<float>(seg + 1) * segment_steps);
+                const int seg_steps = seg_end - seg_start;
+
+                for (auto i = 0; i < seg_steps; i++) {
+                    const float ratio = static_cast<float>(i) / static_cast<float>(seg_steps);
+                    auto [s_r, s_g, s_b] = start.get_color();
+                    auto [e_r, e_g, e_b] = end.get_color();
+                    auto r = static_cast<uint8_t>(static_cast<float>(s_r) + ratio * static_cast<float>(e_r - s_r));
+                    auto g = static_cast<uint8_t>(static_cast<float>(s_g) + ratio * static_cast<float>(e_g - s_g));
+                    auto b = static_cast<uint8_t>(static_cast<float>(s_b) + ratio * static_cast<float>(e_b - s_b));
+                    gradient.emplace_back(r, g, b);
+                }
+            }
+
+            if (gradient.size() > static_cast<size_t>(steps)) {
+                gradient.resize(steps);
+            } else if (gradient.size() < static_cast<size_t>(steps)) {
+                do {
+                    gradient.push_back(color_points.back());
+                } while (gradient.size() < static_cast<size_t>(steps));
+            }
+
+            return gradient;
+        }
+
+        [[nodiscard]] std::tuple<uint8_t, uint8_t, uint8_t> get_color() const {
+            return std::make_tuple(this->r_, this->g_, this->b_);
+        }
+
+    private:
+        uint8_t r_;
+        uint8_t g_;
+        uint8_t b_;
     };
 } // namespace tui_extras

--- a/include/rebuildTUI/styles.hpp
+++ b/include/rebuildTUI/styles.hpp
@@ -13,20 +13,21 @@ namespace tui_extras {
     enum class BorderStyle { ROUNDED, DOUBLE, SHARP, ASCII };
 
     enum class AccentColor {
-        CYAN,
-        BLUE,
-        GREEN,
-        RED,
-        YELLOW,
-        MAGENTA,
-        WHITE,
-        BRIGHT_CYAN,
-        BRIGHT_BLUE,
-        BRIGHT_GREEN,
-        BRIGHT_RED,
-        BRIGHT_YELLOW,
-        BRIGHT_MAGENTA,
-        BRIGHT_WHITE
+        RESET = 0,
+        RED = 31,
+        GREEN = 32,
+        YELLOW = 33,
+        BLUE = 34,
+        MAGENTA = 35,
+        CYAN = 36,
+        WHITE = 37,
+        BRIGHT_RED = 91,
+        BRIGHT_GREEN = 92,
+        BRIGHT_YELLOW = 93,
+        BRIGHT_BLUE = 94,
+        BRIGHT_MAGENTA = 95,
+        BRIGHT_CYAN = 96,
+        BRIGHT_WHITE = 97
     };
 
     class GradientPreset {

--- a/include/rebuildTUI/styles.hpp
+++ b/include/rebuildTUI/styles.hpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <random>
 #include <tuple>
 #include <vector>
 
@@ -140,8 +139,6 @@ namespace tui_extras {
                     GradientColor{255, 0, 255}, // Magenta
                     GradientColor{255, 0, 0}    // Red
                 };
-
-                std::ranges::shuffle(color_points, std::mt19937(std::random_device()()));
                 break;
             case GradientPreset::PresetType::CUSTOM:
                 {

--- a/include/rebuildTUI/styles.hpp
+++ b/include/rebuildTUI/styles.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <random>
 #include <tuple>
 #include <vector>
 
@@ -94,6 +96,8 @@ namespace tui_extras {
                     GradientColor{255, 0, 255}, // Magenta
                     GradientColor{255, 0, 0}    // Red
                 };
+
+                std::ranges::shuffle(color_points, std::mt19937(std::random_device()()));
                 break;
             default:
                 return {GradientColor{255, 255, 255}};

--- a/include/rebuildTUI/terminal_utils.hpp
+++ b/include/rebuildTUI/terminal_utils.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <iostream>
-#include <optional>
-#include <string>
-
 #include "styles.hpp"
+
+#include <iostream>
 
 #ifdef _WIN32
 #include <conio.h>
@@ -104,6 +102,8 @@ namespace tui {
         static std::pair<int, int> get_terminal_size();
         static void set_color(Color color);
 
+        static bool is_windows_terminal();
+
         // Gradient
         static void set_color_rgb(uint8_t r, uint8_t g, uint8_t b);
         static void set_color_rgb(tui_extras::GradientColor color);
@@ -150,6 +150,7 @@ namespace tui {
         static HANDLE hConsole;
         static CONSOLE_SCREEN_BUFFER_INFO csbi;
         static DWORD originalConsoleMode;
+        static bool is_wt;
 #else
         static struct termios original_termios;
         static bool termios_saved;

--- a/include/rebuildTUI/terminal_utils.hpp
+++ b/include/rebuildTUI/terminal_utils.hpp
@@ -106,7 +106,6 @@ namespace tui {
 
         // Gradient
         static void set_color_rgb(uint8_t r, uint8_t g, uint8_t b);
-        static void set_color_rgb(tui_extras::GradientColor &color);
         static void set_color_rgb(tui_extras::GradientColor color);
 
         static void set_style(Style style);

--- a/include/rebuildTUI/terminal_utils.hpp
+++ b/include/rebuildTUI/terminal_utils.hpp
@@ -102,8 +102,6 @@ namespace tui {
         static std::pair<int, int> get_terminal_size();
         static void set_color(Color color);
 
-        static bool is_windows_terminal();
-
         // Gradient
         static void set_color_rgb(uint8_t r, uint8_t g, uint8_t b);
         static void set_color_rgb(tui_extras::GradientColor color);

--- a/include/rebuildTUI/terminal_utils.hpp
+++ b/include/rebuildTUI/terminal_utils.hpp
@@ -4,6 +4,8 @@
 #include <optional>
 #include <string>
 
+#include "styles.hpp"
+
 #ifdef _WIN32
 #include <conio.h>
 #include <windows.h>
@@ -101,6 +103,12 @@ namespace tui {
         static void show_cursor();
         static std::pair<int, int> get_terminal_size();
         static void set_color(Color color);
+
+        // Gradient
+        static void set_color_rgb(uint8_t r, uint8_t g, uint8_t b);
+        static void set_color_rgb(tui_extras::GradientColor &color);
+        static void set_color_rgb(tui_extras::GradientColor color);
+
         static void set_style(Style style);
         static void reset_formatting();
 

--- a/include/rebuildTUI/terminal_utils.hpp
+++ b/include/rebuildTUI/terminal_utils.hpp
@@ -101,6 +101,7 @@ namespace tui {
         static void show_cursor();
         static std::pair<int, int> get_terminal_size();
         static void set_color(Color color);
+        static void set_color(tui_extras::AccentColor color);
 
         // Gradient
         static void set_color_rgb(uint8_t r, uint8_t g, uint8_t b);

--- a/include/rebuildTUI/terminal_utils.hpp
+++ b/include/rebuildTUI/terminal_utils.hpp
@@ -36,7 +36,7 @@ namespace tui {
             END = 11,
             PAGE_UP = 12,
             PAGE_DOWN = 13,
-            DELETE = 14,
+            KEY_DELETE = 14,
             KEY_J = 15,
             KEY_K = 16,
             KEY_H = 17,

--- a/src/navigation_tui.cpp
+++ b/src/navigation_tui.cpp
@@ -672,11 +672,11 @@ namespace tui {
         }
 
         const auto steps = static_cast<int>(text.length());
-        auto gradient = tui_extras::GradientColor::from_preset(config_.theme.gradient_preset, steps);
+        const auto gradient = tui_extras::GradientColor::from_preset(config_.theme.gradient_preset, steps);
 
         for (auto i = 0; i < steps; i++) {
             TerminalUtils::move_cursor(row, col + i);
-            // TerminalUtils::set_color_rgb(gradient[i]);
+            TerminalUtils::set_color_rgb(gradient[i]);
             std::cout << text[i];
         }
 

--- a/src/navigation_tui.cpp
+++ b/src/navigation_tui.cpp
@@ -1,12 +1,11 @@
 #include "navigation_tui.hpp"
-#include <algorithm>
-#include <iostream>
+#include "styles.hpp"
+#include "terminal_utils.hpp"
+
+#include <random>
 #include <sstream>
 #include <thread>
 #include <utility>
-
-#include "styles.hpp"
-#include "terminal_utils.hpp"
 
 namespace tui {
     NavigationTUI::NavigationTUI() :
@@ -672,7 +671,11 @@ namespace tui {
             return;
         }
 
-        const auto gradient = tui_extras::GradientColor::from_preset(config_.theme.gradient_preset, steps);
+        auto gradient = tui_extras::GradientColor::from_preset(config_.theme.gradient_preset, steps);
+
+        if (config_.theme.gradient_randomize) {
+            std::ranges::shuffle(gradient, std::mt19937(std::random_device()()));
+        }
 
         TerminalUtils::move_cursor(row, col);
 
@@ -1008,6 +1011,11 @@ namespace tui {
 
     NavigationBuilder &NavigationBuilder::theme_gradient_preset(const tui_extras::GradientPreset &preset) {
         config_.theme.gradient_preset = preset;
+        return *this;
+    }
+
+    NavigationBuilder &NavigationBuilder::theme_gradient_randomize(const bool enable) {
+        config_.theme.gradient_randomize = enable;
         return *this;
     }
 

--- a/src/navigation_tui.cpp
+++ b/src/navigation_tui.cpp
@@ -666,6 +666,23 @@ namespace tui {
         }
     }
 
+    void NavigationTUI::apply_gradient_text(const std::string &text, const int row, const int col) const {
+        if (!config_.theme.gradient_enabled || config_.theme.gradient_preset == tui_extras::GradientPreset::NONE) {
+            return;
+        }
+
+        const auto steps = static_cast<int>(text.length());
+        auto gradient = tui_extras::GradientColor::from_preset(config_.theme.gradient_preset, steps);
+
+        for (auto i = 0; i < steps; i++) {
+            TerminalUtils::move_cursor(row, col + i);
+            // TerminalUtils::set_color_rgb(gradient[i]);
+            std::cout << text[i];
+        }
+
+        TerminalUtils::reset_formatting();
+    }
+
     void NavigationTUI::render_section_selection(const int start_row, const int left_padding, const int content_width) {
         // Header
         TerminalUtils::move_cursor(start_row, left_padding);

--- a/src/navigation_tui.cpp
+++ b/src/navigation_tui.cpp
@@ -640,31 +640,6 @@ namespace tui {
         std::cout << separator << "\n\n";
     }
 
-    // TODO: simplify this
-    void NavigationTUI::apply_accent_color() const {
-        static const std::map<tui_extras::AccentColor, TerminalUtils::Color> color_map = {
-            {tui_extras::AccentColor::CYAN, TerminalUtils::Color::CYAN},
-            {tui_extras::AccentColor::BLUE, TerminalUtils::Color::BLUE},
-            {tui_extras::AccentColor::GREEN, TerminalUtils::Color::GREEN},
-            {tui_extras::AccentColor::RED, TerminalUtils::Color::RED},
-            {tui_extras::AccentColor::YELLOW, TerminalUtils::Color::YELLOW},
-            {tui_extras::AccentColor::MAGENTA, TerminalUtils::Color::MAGENTA},
-            {tui_extras::AccentColor::WHITE, TerminalUtils::Color::WHITE},
-            {tui_extras::AccentColor::BRIGHT_CYAN, TerminalUtils::Color::BRIGHT_CYAN},
-            {tui_extras::AccentColor::BRIGHT_BLUE, TerminalUtils::Color::BRIGHT_BLUE},
-            {tui_extras::AccentColor::BRIGHT_GREEN, TerminalUtils::Color::BRIGHT_GREEN},
-            {tui_extras::AccentColor::BRIGHT_RED, TerminalUtils::Color::BRIGHT_RED},
-            {tui_extras::AccentColor::BRIGHT_YELLOW, TerminalUtils::Color::BRIGHT_YELLOW},
-            {tui_extras::AccentColor::BRIGHT_MAGENTA, TerminalUtils::Color::BRIGHT_MAGENTA},
-            {tui_extras::AccentColor::BRIGHT_WHITE, TerminalUtils::Color::BRIGHT_WHITE}};
-
-        if (const auto it = color_map.find(config_.theme.accent_color); it != color_map.end()) {
-            TerminalUtils::set_color(it->second);
-        } else {
-            TerminalUtils::set_color(TerminalUtils::Color::CYAN);
-        }
-    }
-
     void NavigationTUI::apply_gradient_text(const std::string &text, const int row, const int col) const {
         const auto steps = static_cast<int>(text.length());
         if (steps == 0) {
@@ -729,7 +704,7 @@ namespace tui {
 
                     apply_gradient_text(text, items_start_row + i, centered_col);
                 } else if (config_.theme.use_colors) {
-                    apply_accent_color();
+                    TerminalUtils::set_color(config_.theme.accent_color);
                     std::cout << t_content;
                     TerminalUtils::reset_formatting();
                 } else {
@@ -784,7 +759,7 @@ namespace tui {
                                             centered_col);
                     } else {
                         if (config_.theme.use_colors) {
-                            apply_accent_color();
+                            TerminalUtils::set_color(config_.theme.accent_color);
                         }
                         std::cout << content;
                         TerminalUtils::reset_formatting();

--- a/src/navigation_tui.cpp
+++ b/src/navigation_tui.cpp
@@ -721,7 +721,7 @@ namespace tui {
 
             if (i == static_cast<int>(current_selection_index_)) {
                 if (config_.theme.gradient_enabled &&
-                    config_.theme.gradient_preset != tui_extras::GradientPreset::NONE) {
+                    config_.theme.gradient_preset != tui_extras::GradientPreset::NONE()) {
                     std::cout << t_content;
 
                     apply_gradient_text(text, items_start_row + i, centered_col);
@@ -773,19 +773,19 @@ namespace tui {
                 const auto [content, line_count] = center_string(display_text, content_width);
                 const auto centered_col = left_padding + (content_width - static_cast<int>(display_text.length())) / 2;
 
-                if (!(i - first == current_selection_index_)) {
+                if (i - first != current_selection_index_) {
                     std::cout << content;
-                    return;
-                }
-
-                if (config_.theme.gradient_enabled) {
-                    apply_gradient_text(display_text, static_cast<int>(items_start_row + (i - first)), centered_col);
                 } else {
-                    if (config_.theme.use_colors) {
-                        apply_accent_color();
+                    if (config_.theme.gradient_enabled) {
+                        apply_gradient_text(display_text, static_cast<int>(items_start_row + (i - first)),
+                                            centered_col);
+                    } else {
+                        if (config_.theme.use_colors) {
+                            apply_accent_color();
+                        }
+                        std::cout << content;
+                        TerminalUtils::reset_formatting();
                     }
-                    std::cout << content;
-                    TerminalUtils::reset_formatting();
                 }
             }
         }

--- a/src/navigation_tui.cpp
+++ b/src/navigation_tui.cpp
@@ -735,7 +735,7 @@ namespace tui {
             for (size_t i = first; i < second; ++i) {
                 TerminalUtils::move_cursor(static_cast<int>(items_start_row + (i - first)), left_padding);
 
-                if ((i - first) == current_selection_index_ && config_.theme.use_colors) {
+                if (i - first == current_selection_index_ && config_.theme.use_colors) {
                     apply_accent_color();
                 }
 
@@ -745,7 +745,7 @@ namespace tui {
                     std::cout << center_string(display_text, content_width).content;
                 }
 
-                if ((i - first) == current_selection_index_ && config_.theme.use_colors) {
+                if (i - first == current_selection_index_ && config_.theme.use_colors) {
                     TerminalUtils::reset_formatting();
                 }
             }

--- a/src/navigation_tui.cpp
+++ b/src/navigation_tui.cpp
@@ -723,7 +723,7 @@ namespace tui {
             for (size_t i = first; i < second; ++i) {
                 TerminalUtils::move_cursor(static_cast<int>(items_start_row + (i - first)), left_padding);
 
-                if ((i - first) == current_selection_index_ && config_.theme.use_colors) {
+                if (i - first == current_selection_index_ && config_.theme.use_colors) {
                     apply_accent_color();
                 }
 
@@ -733,7 +733,7 @@ namespace tui {
                     std::cout << center_string(display_text, content_width).content;
                 }
 
-                if ((i - first) == current_selection_index_ && config_.theme.use_colors) {
+                if (i - first == current_selection_index_ && config_.theme.use_colors) {
                     TerminalUtils::reset_formatting();
                 }
             }

--- a/src/terminal_utils.cpp
+++ b/src/terminal_utils.cpp
@@ -173,6 +173,25 @@ namespace tui {
 #endif
     }
 
+    void TerminalUtils::set_color_rgb(uint8_t r, uint8_t g, uint8_t b) {
+#ifdef _WIN32
+        printf("\033[38;2;%d;%d;%dm", r, g, b);
+#else
+        std::cout << std::format("\033[38;2;{};{};{};m", static_cast<int>(r), static_cast<int>(g), static_cast<int>(b));
+#endif
+        flush();
+    }
+
+    void TerminalUtils::set_color_rgb(tui_extras::GradientColor &color) {
+        auto &[r, g, b] = color.get_color();
+        set_color_rgb(r, g, b);
+    }
+
+    void TerminalUtils::set_color_rgb(const tui_extras::GradientColor color) {
+        auto [r, g, b] = color.get_color();
+        set_color_rgb(r, g, b);
+    }
+
     void TerminalUtils::set_style(Style style) {
 #ifdef _WIN32
         // Windows console doesn't support all styles, so we'll do our best

--- a/src/terminal_utils.cpp
+++ b/src/terminal_utils.cpp
@@ -624,6 +624,10 @@ namespace tui {
             }
         }
         is_wt = std::getenv("WT_SESSION") ? true : false;
+        SetConsoleOutputCP(CP_UTF8);
+        SetConsoleCP(CP_UTF8);
+
+        hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 #else
         if (tcgetattr(STDIN_FILENO, &original_termios) == 0) {
             termios_saved = true;

--- a/src/terminal_utils.cpp
+++ b/src/terminal_utils.cpp
@@ -371,7 +371,7 @@ namespace tui {
                     return {Key::PAGE_DOWN, 0};
                 case '3':
                     get_key();
-                    return {Key::DELETE, 0};
+                    return {Key::KEY_DELETE, 0};
                 default:
                     return {Key::UNKNOWN, 0};
                 }
@@ -413,7 +413,7 @@ namespace tui {
             case 81:
                 return {Key::PAGE_DOWN, 0};
             case 83:
-                return {Key::DELETE, 0};
+                return {Key::KEY_DELETE, 0};
             default:
                 return {Key::UNKNOWN, 0};
             }

--- a/src/terminal_utils.cpp
+++ b/src/terminal_utils.cpp
@@ -182,11 +182,6 @@ namespace tui {
         flush();
     }
 
-    void TerminalUtils::set_color_rgb(tui_extras::GradientColor &color) {
-        auto &[r, g, b] = color.get_color();
-        set_color_rgb(r, g, b);
-    }
-
     void TerminalUtils::set_color_rgb(const tui_extras::GradientColor color) {
         auto [r, g, b] = color.get_color();
         set_color_rgb(r, g, b);

--- a/src/terminal_utils.cpp
+++ b/src/terminal_utils.cpp
@@ -175,6 +175,72 @@ namespace tui {
 #endif
     }
 
+    void TerminalUtils::set_color(tui_extras::AccentColor color) {
+#ifdef _WIN32
+        if (hConsole != INVALID_HANDLE_VALUE) {
+            WORD attributes = 0;
+            switch (color) {
+            case Color::BLACK:
+                attributes = 0;
+                break;
+            case Color::RED:
+                attributes = FOREGROUND_RED;
+                break;
+            case Color::GREEN:
+                attributes = FOREGROUND_GREEN;
+                break;
+            case Color::YELLOW:
+                attributes = FOREGROUND_RED | FOREGROUND_GREEN;
+                break;
+            case Color::BLUE:
+                attributes = FOREGROUND_BLUE;
+                break;
+            case Color::MAGENTA:
+                attributes = FOREGROUND_RED | FOREGROUND_BLUE;
+                break;
+            case Color::CYAN:
+                attributes = FOREGROUND_GREEN | FOREGROUND_BLUE;
+                break;
+            case Color::WHITE:
+                attributes = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+                break;
+            case Color::BRIGHT_BLACK:
+                attributes = FOREGROUND_INTENSITY;
+                break;
+            case Color::BRIGHT_RED:
+                attributes = FOREGROUND_RED | FOREGROUND_INTENSITY;
+                break;
+            case Color::BRIGHT_GREEN:
+                attributes = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+                break;
+            case Color::BRIGHT_YELLOW:
+                attributes = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+                break;
+            case Color::BRIGHT_BLUE:
+                attributes = FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+                break;
+            case Color::BRIGHT_MAGENTA:
+                attributes = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+                break;
+            case Color::BRIGHT_CYAN:
+                attributes = FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+                break;
+            case Color::BRIGHT_WHITE:
+                attributes = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+                break;
+            default:
+                attributes = csbi.wAttributes;
+                break;
+            }
+            SetConsoleTextAttribute(hConsole, attributes);
+        }
+#else
+        std::cout << std::format("\033[{}m", (color == tui_extras::AccentColor::RESET) ? 0 : static_cast<int>(color));
+
+        flush();
+#endif
+    }
+
     void TerminalUtils::set_color_rgb(uint8_t r, uint8_t g, uint8_t b) {
         // #ifdef _WIN32
         //         printf("\033[38;2;%d;%d;%dm", r, g, b);

--- a/src/terminal_utils.cpp
+++ b/src/terminal_utils.cpp
@@ -174,11 +174,11 @@ namespace tui {
     }
 
     void TerminalUtils::set_color_rgb(uint8_t r, uint8_t g, uint8_t b) {
-#ifdef _WIN32
-        printf("\033[38;2;%d;%d;%dm", r, g, b);
-#else
-        std::cout << std::format("\033[38;2;{};{};{};m", static_cast<int>(r), static_cast<int>(g), static_cast<int>(b));
-#endif
+// #ifdef _WIN32
+//         printf("\033[38;2;%d;%d;%dm", r, g, b);
+// #else
+        std::cout << std::format("\033[38;2;{};{};{}m", static_cast<int>(r), static_cast<int>(g), static_cast<int>(b));
+// #endif
         flush();
     }
 

--- a/src/terminal_utils.cpp
+++ b/src/terminal_utils.cpp
@@ -109,11 +109,6 @@ namespace tui {
 #endif
     }
 
-    bool TerminalUtils::is_windows_terminal() {
-        const auto terminal = std::getenv("WT_SESSION");
-        return terminal && *terminal;
-    }
-
     void TerminalUtils::set_color(Color color) {
 #ifdef _WIN32
         if (hConsole != INVALID_HANDLE_VALUE) {
@@ -191,7 +186,6 @@ namespace tui {
 
     void TerminalUtils::set_color_rgb(const tui_extras::GradientColor color) {
 #ifdef _WIN32
-        // const bool is_wt = is_windows_terminal();
         if (!is_wt) {
             return;
         }
@@ -629,7 +623,7 @@ namespace tui {
                 SetConsoleMode(hInput, ENABLE_PROCESSED_INPUT);
             }
         }
-        is_wt = is_windows_terminal();
+        is_wt = std::getenv("WT_SESSION") ? true : false;
 #else
         if (tcgetattr(STDIN_FILENO, &original_termios) == 0) {
             termios_saved = true;


### PR DESCRIPTION
TODO:
- [x] impl GradientPreset::CUSTOM (accept custom values)
- [x] impl theme_gradient_randomize function + option
- [x] review code related with Gradients
- [x] add check if TUI running on the Windows Terminal


Available presets
- GradientPreset::RAINBOW
- GradientPreset::BLUE_TO_PURPLE
- GradientPreset::RED_TO_GREEN
- GradientPreset::FIRE            - Red to yellow
- GradientPreset::FOREST          - Green to yellow-green
- GradientPreset::OCEAN           - Blue to turquoise
- GradientPreset::WARM_TO_COLD    - From orange to cyan
- GradientPreset::SUNSET          - Red -> orange -> violet
- GradientPreset::NONE            - None (by default)
- GradientPreset::CUSTOM      - Custom